### PR TITLE
Fix Inconsistency in Function Names

### DIFF
--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -56,7 +56,7 @@ describe('drivers', function () {
     });
   });
 
-  describe('destructivelyDeleteFromdriverByKey(driver, key)', function () {
+  describe('destructivelyDeleteFromDriverByKey(driver, key)', function () {
     it('returns driver without the delete key/value pair', function () {
       let newdriver = destructivelyDeleteFromDriverByKey(driver, 'name');
 


### PR DESCRIPTION
There was an issue a user had (described below in the image) that was a result of a function name on this file not being the same as the expected function name in the test.

![image](https://user-images.githubusercontent.com/2770126/32476092-4604af7a-c343-11e7-9562-e1f252535b8d.png)
